### PR TITLE
fix: use sender US number for CA number

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -26,6 +26,7 @@ function init({ config }) {
         senderIdMap: {
             US: config["NEXMO_SENDER_ID_US"],
             VN: config["NEXMO_SENDER_ID_VN"],
+            CA: config["NEXMO_SENDER_ID_US"],
         },
         logger: logger,
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded SMS functionality to support sending messages to Canada using the existing US sender ID.

- **Bug Fixes**
	- Improved initialization of the SMS component for better regional support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->